### PR TITLE
[DNM!!!!!] [3.5] Temporarily disable Pool tiers (OP-2918)

### DIFF
--- a/backend/ceph/models.py
+++ b/backend/ceph/models.py
@@ -326,9 +326,9 @@ class CephPool(NodbModel, RadosMixin):
                 'quota_max_objects': pool_data['quota_max_objects'],
                 # Cache tiering related
                 'cache_mode': pool_data['cache_mode'],
-                'tier_of_id': pool_data['tier_of'] if pool_data['tier_of'] > 0 else None,
-                'write_tier_id': pool_data['write_tier'] if pool_data['write_tier'] > 0 else None,
-                'read_tier_id': pool_data['read_tier'] if pool_data['read_tier'] > 0 else None,
+                'tier_of_id': None,
+                'write_tier_id': None,
+                'read_tier_id': None,
                 # Attributes for cache tiering
                 'target_max_bytes': pool_data['target_max_bytes'],
                 'hit_set_period': pool_data['hit_set_period'],


### PR DESCRIPTION
Cause it will generate an endless recusion via:

```
ceph.models.CephPool#get_all_objects line 348
django. ... ReverseSingleRelatedObjectDescriptor ...
nodb.models.NodbModel#__init__ line 565
ceph.models.CephPool#__init__ line 355
ceph.models.CephPool#get_all_objects line 348

```

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>